### PR TITLE
Android/app/oobe/NameActivity : Fix keyboard show when focusing edittext

### DIFF
--- a/Android/PetEver/app/src/main/java/com/example/petever/oobe/NameActivity.java
+++ b/Android/PetEver/app/src/main/java/com/example/petever/oobe/NameActivity.java
@@ -50,12 +50,12 @@ public class NameActivity extends AppCompatActivity {
         return this.petRelationship;
     }
 
-    void keyBordHide() {
+    void keyBoardHide() {
         Window window = getWindow();
         new WindowInsetsControllerCompat(window, window.getDecorView()).hide(WindowInsetsCompat.Type.ime());
     }
 
-    void keyBordShow() {
+    void keyBoardShow() {
         Window window = getWindow();
         new WindowInsetsControllerCompat(window, window.getDecorView()).show(WindowInsetsCompat.Type.ime());
     }
@@ -83,7 +83,7 @@ public class NameActivity extends AppCompatActivity {
                     case MotionEvent.ACTION_DOWN:
                     case MotionEvent.ACTION_UP:
                         hidden_layer.setVisibility(View.INVISIBLE);
-                        hideKeyboard();
+                        keyBoardHide();
                 }
                 return false;
             }
@@ -122,11 +122,9 @@ public class NameActivity extends AppCompatActivity {
         name_new.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
-                keyBordShow();
                 switch (actionId) {
                     case EditorInfo.IME_ACTION_DONE:
-//                        hideKeyboard();
-                        keyBordHide();
+                        keyBoardHide();
                     case EditorInfo.IME_ACTION_NEXT:
                     default:
                         // Save the Pet Name into global variable, petName
@@ -154,12 +152,10 @@ public class NameActivity extends AppCompatActivity {
         relation_new.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
-                keyBordShow();
                 switch (actionId) {
                     case EditorInfo.IME_ACTION_NEXT:
                     case EditorInfo.IME_ACTION_DONE:
-//                        hideKeyboard();
-                        keyBordHide();
+                        keyBoardHide();
                     default:
                         // Save the Relationship into global variable, petRelationship
                         petRelationship = v.getText().toString();


### PR DESCRIPTION
When focusing the edittext, keyboard should be shown up automatically.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>