### PR TITLE
ReferenceCodes/VoiceRecognition/PetEverVoice.java : Set null to

### DIFF
--- a/ReferenceCodes/VoiceRecognition/PetEverVoice/src/main/java/com/example/petevervoice/PetEverVoice.java
+++ b/ReferenceCodes/VoiceRecognition/PetEverVoice/src/main/java/com/example/petevervoice/PetEverVoice.java
@@ -178,6 +178,7 @@ public class PetEverVoice {
             isRecogDone = true;
             mRecognizer.cancel();
             mRecognizer.destroy();
+            mRecognizer = null;
         }
 
         @Override


### PR DESCRIPTION
mRecognizer after destroying

After destroying mRecognizer, set to null.
Because when invoking the recognizer, creating the recognizer if it is null.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>