### PR TITLE
Android/app/oobe/BreedActivity : Fix null of preference

### DIFF
--- a/Android/PetEver/app/src/main/java/com/example/petever/oobe/BreedActivity.java
+++ b/Android/PetEver/app/src/main/java/com/example/petever/oobe/BreedActivity.java
@@ -68,6 +68,8 @@ public class BreedActivity extends AppCompatActivity {
             breed = extras.getStringExtra("breed");
             fileUri = Uri.parse(imagePath);
         }
+
+        pf = getSharedPreferences("PetInfo", MODE_PRIVATE);
     }
 
     private void processView() {


### PR DESCRIPTION
Because of missing to get the shared preference pointer, it can be null.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>