### PR TITLE
Unity/PetEver/ProjectSettings : Add Draw Canvas Scene to ProjectSettings

### DIFF
--- a/Unity/PetEver/ProjectSettings/EditorBuildSettings.asset
+++ b/Unity/PetEver/ProjectSettings/EditorBuildSettings.asset
@@ -12,6 +12,6 @@ EditorBuildSettings:
     path: Assets/01.Scenes/newScene.unity
     guid: 8adc327f7b2c46845a198f25bc0a8fab
   - enabled: 1
-    path: Assets/01.Scenes/newScene_1.unity
-    guid: 67a8297991378154db6c3dbcba5e7f3e
+    path: Assets/FreeDraw/CanvasScene.unity
+    guid: 4ce4d4d4aeef2e54e97bb40827915db8
   m_configObjects: {}


### PR DESCRIPTION
To use Draw Canvas Scene loading, it should be added to ProjectSettings.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>