### PR TITLE
Unity/PetEver/Assets : Change active state when enter/exit from

### DIFF
--- a/Unity/PetEver/Assets/01.Scenes/newScene.unity
+++ b/Unity/PetEver/Assets/01.Scenes/newScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028334, g: 0.2257134, b: 0.30692226, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -312,7 +312,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 575880397}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -15.64, y: 0, z: -30.31}
+  m_LocalPosition: {x: -22.83, y: 0, z: -30.31}
   m_LocalScale: {x: 1.4002, y: 4.7626038, z: 2.6327407}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Unity/PetEver/Assets/02.Scripts/CallCanvas.cs
+++ b/Unity/PetEver/Assets/02.Scripts/CallCanvas.cs
@@ -16,14 +16,7 @@ public class CallCanvas : MonoBehaviour
         mainCanvas = GameObject.Find("MainCanvas");
         mainEventSystem = GameObject.Find("MainEventSystem");
 
-        ManCharacter.SetActive(true);
-        mainCanvas.SetActive(true);
-        mainEventSystem.SetActive(true);
-    }
-
-    public void LoadScene(string drawCanvas)
-    {
-        StartCoroutine(LoadYourAsyncScene(drawCanvas));
+        SceneManager.SetActiveScene(SceneManager.GetSceneByName("newScene"));
     }
 
     IEnumerator<object> LoadYourAsyncScene(string drawCanvas)
@@ -36,7 +29,9 @@ public class CallCanvas : MonoBehaviour
         {
             yield return null;
         }
- 
+
+        SceneManager.SetActiveScene(SceneManager.GetSceneByName(drawCanvas));
+
         SceneManager.MoveGameObjectToScene(ManCharacter, SceneManager.GetSceneByName(drawCanvas));
         SceneManager.MoveGameObjectToScene(mainEventSystem, SceneManager.GetSceneByName(drawCanvas));
         SceneManager.MoveGameObjectToScene(mainCanvas, SceneManager.GetSceneByName(drawCanvas));
@@ -46,6 +41,6 @@ public class CallCanvas : MonoBehaviour
  
     private void OnCollisionEnter(Collision collision)
     {
-        LoadScene("CanvasScene");
+        StartCoroutine(LoadYourAsyncScene("CanvasScene"));
     }
 }

--- a/Unity/PetEver/Assets/FreeDraw/CanvasScene.unity
+++ b/Unity/PetEver/Assets/FreeDraw/CanvasScene.unity
@@ -1192,7 +1192,7 @@ AudioListener:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 734722397}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!124 &734722399
 Behaviour:
   m_ObjectHideFlags: 0

--- a/Unity/PetEver/Assets/FreeDraw/Scripts/DrawingSettings.cs
+++ b/Unity/PetEver/Assets/FreeDraw/Scripts/DrawingSettings.cs
@@ -10,19 +10,23 @@ public class DrawingSettings : MonoBehaviour
     public static bool isCursorOverUI = false;
     public float Transparency = 1f;
 
-    GameObject ManCharacter;
-    GameObject mainCanvas;
-    GameObject mainEventSystem;
+    GameObject ManCharacter = null;
+    GameObject ManHead;
+    GameObject mainCanvas = null;
+    GameObject mainEventSystem = null;
 
     void Start()
     {
         ManCharacter = GameObject.Find("Man");
+        ManHead = GameObject.Find("head");
         mainCanvas = GameObject.Find("MainCanvas");
         mainEventSystem = GameObject.Find("MainEventSystem");
 
-        ManCharacter.SetActive(false);
-        mainCanvas.SetActive(false);
-        mainEventSystem.SetActive(false);
+        ManHead.GetComponent<SkinnedMeshRenderer>().enabled = false;
+        mainEventSystem.GetComponent<EventSystem>().enabled = false;
+        mainCanvas.GetComponent<Canvas>().enabled = false;
+
+        SceneManager.SetActiveScene(SceneManager.GetSceneByName("CanvasScene"));
     }
 
     // Changing pen settings is easy as changing the static properties Drawable.Pen_Colour and Drawable.Pen_Width
@@ -97,6 +101,8 @@ public class DrawingSettings : MonoBehaviour
             yield return null;
         }
 
+        SceneManager.SetActiveScene(SceneManager.GetSceneByName(scene));
+
         SceneManager.MoveGameObjectToScene(ManCharacter, SceneManager.GetSceneByName(scene));
         SceneManager.MoveGameObjectToScene(mainEventSystem, SceneManager.GetSceneByName(scene));
         SceneManager.MoveGameObjectToScene(mainCanvas, SceneManager.GetSceneByName(scene));
@@ -106,10 +112,10 @@ public class DrawingSettings : MonoBehaviour
 
     public void MoveBackToHome()
     {
-        ManCharacter.SetActive(true);
-        mainCanvas.SetActive(true);
-        mainEventSystem.SetActive(true);
-
+        ManHead.GetComponent<SkinnedMeshRenderer>().enabled = true;
+        mainEventSystem.GetComponent<EventSystem>().enabled = true;
+        mainCanvas.GetComponent<Canvas>().enabled = true;
+        
         StartCoroutine(LoadBack("newScene"));
     }
 


### PR DESCRIPTION
DrawCanvas

Man, MainCanvas, MainEventSystem will hide when enter to DrawCanvas. After returning to newScene, show them again.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>