### PR TITLE
Unity/DrawCanvas : Reset the canvas when calling the canvas

### DIFF
--- a/Unity/PetEver/Assets/02.Scripts/CallCanvas.cs
+++ b/Unity/PetEver/Assets/02.Scripts/CallCanvas.cs
@@ -39,6 +39,7 @@ public class CallCanvas : MonoBehaviour
             mainCanvas.SetActive(false);
             MainCamera.GetComponent<Camera>().enabled = false;
 
+            DrawingSettings.SetEraseAll();
             CanvasEventSystem.SetActive(true);
             DrawCanvas.SetActive(true);
             DrawCanvasCamera.GetComponent<Camera>().enabled = true;

--- a/Unity/PetEver/Assets/FreeDraw/Scripts/DrawingSettings.cs
+++ b/Unity/PetEver/Assets/FreeDraw/Scripts/DrawingSettings.cs
@@ -73,7 +73,7 @@ public class DrawingSettings : MonoBehaviour
         SetMarkerColour(new Color(255f, 255f, 255f, 255f));
     }
 
-    public void SetEraseAll()
+    public static void SetEraseAll()
     {
         Drawable.drawable.ResetCanvas();
     }


### PR DESCRIPTION
After drawing something, and calling the canvas again, previous drawn was remained. So reset the canvas when calling the canvas again.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>