### PR TITLE
Unity/WorldScene : Show House Info as Hospital

### DIFF
--- a/Unity/PetEver/Assets/01.Scenes/WorldScene.unity
+++ b/Unity/PetEver/Assets/01.Scenes/WorldScene.unity
@@ -222,7 +222,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 172900325}
   m_LocalRotation: {x: -0, y: 0.20353295, z: -0, w: 0.97906816}
-  m_LocalPosition: {x: 0, y: 0, z: 31.52}
+  m_LocalPosition: {x: 0, y: 0, z: 29.01}
   m_LocalScale: {x: 0.03770623, y: 0.03770623, z: 0.03770623}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -232,7 +232,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 23.487, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 16.32, y: -13.84}
+  m_AnchoredPosition: {x: 15.23, y: -11.65}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &172900327
@@ -2164,7 +2164,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 61.6, y: -6.7}
+  m_AnchoredPosition: {x: 61.6, y: 12.8}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1576151196
@@ -2189,8 +2189,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: New Text
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7d50f6999ff42eb419823fa7563a00d8, type: 2}
+  m_sharedMaterial: {fileID: 6457400929453644768, guid: 7d50f6999ff42eb419823fa7563a00d8, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2221,8 +2221,8 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -8913,6 +8913,7 @@ GameObject:
   - component: {fileID: 2507020313539638426}
   - component: {fileID: 2094874461}
   - component: {fileID: 2094874462}
+  - component: {fileID: 7651078352455387276}
   m_Layer: 0
   m_Name: HospitalInfo
   m_TagString: Untagged
@@ -10231,6 +10232,18 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6635370232448890480}
   m_Mesh: {fileID: 8022528044143487785, guid: c31ae0a6988d32f4fbf0883381418472, type: 3}
+--- !u!114 &7651078352455387276
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6635370232448890480}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b0b17075ed6aa3445a99d569297989e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &7741505737671337581
 Transform:
   m_ObjectHideFlags: 0

--- a/Unity/PetEver/Assets/02.Scripts/ShowHouseName.cs
+++ b/Unity/PetEver/Assets/02.Scripts/ShowHouseName.cs
@@ -4,23 +4,43 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 
+/* reference : https://jacobjea.tistory.com/7 */
 public class ShowHouseName : MonoBehaviour
 {
-    // GameObject bubble;
-    // Text bubbleTxt;
-    // void Start() {
-    //     bubble = GameObject.FindGameObjectWithTag("SpeechBubble");
-    //     bubbleTxt = GameObject.Find("BubbleText").GetComponent<Text>();
-    // }
+    /** SHOULD BE CHANGED **/
 
-    // private void OnCollisionEnter(Collision collision)
-    // {
-    //     bubbleTxt.text = "병원";
-    //     bubble.SetActive(true);
-    // }
+    /* House Information */
+    private string houseName = "병원정보\n공유의집";
+    private string bubbleName = "SpeechBubble";
+    private string bubbleTxtName = "BubbleText";
+    /*********************/
 
-    // private void OnCollisionExit(Collision collision)
-    // {
-    //     bubble.SetActive(false);
-    // }
+    GameObject bubble;
+    GameObject bubbleBox;
+    GameObject bubbleTxtBox;
+    TextMeshProUGUI bubbleTxt;
+
+    void Start() {
+        bubble = GameObject.FindGameObjectWithTag(bubbleName);
+        bubbleBox = GameObject.Find("BubbleImage");
+        bubbleTxtBox = GameObject.Find(bubbleTxtName);
+        bubbleTxt = GameObject.Find(bubbleTxtName).GetComponent<TextMeshProUGUI>();
+        bubbleBox.SetActive(false);
+        bubble.SetActive(false);
+    }
+
+    private void OnCollisionEnter(Collision collision)
+    {
+        bubble.SetActive(true);
+        bubbleBox.SetActive(true);
+        bubbleTxt.text = houseName;
+        bubbleTxtBox.SetActive(true);
+    }
+
+    private void OnCollisionExit(Collision collision)
+    {
+        bubbleTxtBox.SetActive(false);
+        bubbleBox.SetActive(false);
+        bubble.SetActive(false);
+    }
 }


### PR DESCRIPTION
When character enter the region of the house, it shows the speech-bubble about the information of that house, for example, hospital.

Signed-off-by: jeongchanKim <jc_.kim@samsung.com>