### PR TITLE
Unity/HealingForest : Fix to stop when enter to Healing Forest

### DIFF
--- a/Unity/PetEver/Assets/02.Scripts/HealingForest/HealingGuide.cs
+++ b/Unity/PetEver/Assets/02.Scripts/HealingForest/HealingGuide.cs
@@ -42,14 +42,14 @@ public class HealingGuide : MonoBehaviour
         mainEvent = GameObject.FindGameObjectWithTag("MainEventSystem");
         mainCanvas = GameObject.FindGameObjectWithTag("UICanvas");
         if (mainCanvas) {
-            mainCanvas.SetActive(false);
+            mainCanvas.GetComponent<Canvas>().enabled = false;
         }
 
         healingGuide = GameObject.FindGameObjectWithTag("HealingForestGuide");
         if (isHealingGuided == true) {
             //FIX ME : Allocate when first enter
             Destroy(healingGuide);
-            mainCanvas.SetActive(true);
+            mainCanvas.GetComponent<Canvas>().enabled = true;
         } else {
             isHealingGuided = true;
 
@@ -92,7 +92,7 @@ public class HealingGuide : MonoBehaviour
 
     public static void OnSimpleTestExitClicked()
     {
-        mainCanvas.SetActive(true);
+        mainCanvas.GetComponent<Canvas>().enabled = true;
     }
 
     public void onhealingGuideExit()

--- a/Unity/PetEver/Assets/02.Scripts/PetLossTest/SimpleTestControl.cs
+++ b/Unity/PetEver/Assets/02.Scripts/PetLossTest/SimpleTestControl.cs
@@ -11,7 +11,7 @@ public class SimpleTestControl : MonoBehaviour
         // Initialize the totalScore
         SimpleTest.totalScore = SimpleTest.DEFAULT_TOTALSCORE;
         GameObject previousCanvas = GameObject.FindGameObjectWithTag("SimpleTest");
-        Destroy(previousCanvas, 0.5f);
+        Destroy(previousCanvas);
         HealingGuide.OnSimpleTestExitClicked();
     }
 }

--- a/Unity/PetEver/Assets/03.Prefabs/MainCanvas.prefab
+++ b/Unity/PetEver/Assets/03.Prefabs/MainCanvas.prefab
@@ -4174,7 +4174,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -5021,7 +5021,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &3465192327355526273
 RectTransform:
   m_ObjectHideFlags: 0
@@ -5125,7 +5125,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 3239017192916878301}
   m_Direction: 2
   m_Value: 0
-  m_Size: 1
+  m_Size: 0.99999994
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:


### PR DESCRIPTION
Related to commit 606435a,
when enter to Healing Forest, Character should stop before finishing the Pet-Loss Test.