### PR TITLE
Unity/WorldScene : Add missing DogInfo CanvasGroup on Pome

### DIFF
--- a/Unity/PetEver/Assets/01.Scenes/WorldScene.unity
+++ b/Unity/PetEver/Assets/01.Scenes/WorldScene.unity
@@ -5307,7 +5307,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7e39542b58ac894eaaf45efdb2a4e84, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  dogInfoCG: {fileID: 0}
+  dogInfoCG: {fileID: 744720040122711436, guid: a4b168e251923cd47b56168e331a082b, type: 3}
 --- !u!1 &870247172
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
DogInformation script requires static DogInfo canvas group