### PR TITLE
Unity/DogInfo : Fix Dog Info canvas on Mobile

### DIFF
--- a/Unity/PetEver/Assets/02.Scripts/Info/DogInformation.cs
+++ b/Unity/PetEver/Assets/02.Scripts/Info/DogInformation.cs
@@ -8,22 +8,23 @@ public class DogInformation : MonoBehaviour
 {
     Vector3 m_vecMouseDownPos;
     public GameObject dogInfoCG;
-    GameObject dogInfoCanvas;
+    static GameObject dogInfoCanvas;
+    static GameObject icanvas;
 
     void Start()
     {
+        GameObject canvas = null;
         dogInfoCanvas = GameObject.FindGameObjectWithTag("DogInfo");
         if (dogInfoCanvas == null)
         {
-            GameObject canvas = Instantiate(dogInfoCG) as GameObject;
+            icanvas = Instantiate(dogInfoCG) as GameObject;
         }
-
         controlDogInfoCG(false, null);
     }
 
     private void controlDogInfoCG(bool showflag, Collider dog)
     {
-        dogInfoCG = GameObject.FindGameObjectWithTag("DogInfo");
+        dogInfoCG = icanvas;
         if (showflag == true) {
             dogInfoCG.GetComponent<Canvas>().GetComponent<CanvasGroup>().alpha = 1;
             GameObject targetDog = GameObject.Find(dog.name);
@@ -67,9 +68,7 @@ public class DogInformation : MonoBehaviour
                 if (hit.collider.tag == "NPC" || hit.collider.tag == "OwnerDog") {
                     controlDogInfoCG(true, hit.collider);
                 }
-                
             }
- 
         }
     }
 

--- a/Unity/PetEver/Assets/03.Prefabs/DogInfo.prefab
+++ b/Unity/PetEver/Assets/03.Prefabs/DogInfo.prefab
@@ -285,7 +285,7 @@ GameObject:
   - component: {fileID: 5456146751651766613}
   m_Layer: 5
   m_Name: Placeholder
-  m_TagString: Untagged
+  m_TagString: DogInfo
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2118,7 +2118,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3269245235139646982}
   - component: {fileID: 1760031854320758424}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: ControlDogInfo
   m_TagString: DogInfo
   m_Icon: {fileID: 0}
@@ -3015,7 +3015,7 @@ GameObject:
   - component: {fileID: 497500274519985462}
   m_Layer: 5
   m_Name: Text
-  m_TagString: Untagged
+  m_TagString: DogInfo
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0


### PR DESCRIPTION
On mobile, DogInfo canvas can be null.
So after instantiating it, assign it to global static variable.