### PR TITLE
Unity/MemorialPiece : Set the saved image naming rule

### DIFF
--- a/Unity/PetEver/Assets/02.Scripts/MemorySceneUIScript/NewpageUIManager.cs
+++ b/Unity/PetEver/Assets/02.Scripts/MemorySceneUIScript/NewpageUIManager.cs
@@ -18,7 +18,7 @@ public class NewpageUIManager : MonoBehaviour
     public Button ImageBtn, StickerBtn, TextBtn, CompleteBtn, XBtn;
     public Toggle UploadToggle;
     public static GameObject UserInputTextBundle, StickerInventory, rawImageText;
-    public Transform[] trashCan;
+    public static Transform[] trashCan;
 
     private Vector3 createPoint, stickercreatePoint;
 
@@ -124,7 +124,7 @@ public class NewpageUIManager : MonoBehaviour
             }
     }
 
-    public void CloseUI()
+    public static void CloseUI()
     {
         trashCan = GameObject.Find("MemorialSceneCanvas").GetComponentsInChildren<Transform>();    
 

--- a/Unity/PetEver/Assets/02.Scripts/PiecesDone.cs
+++ b/Unity/PetEver/Assets/02.Scripts/PiecesDone.cs
@@ -25,10 +25,11 @@ public class PiecesDone : MonoBehaviour
         ri = GameObject.Find("TempImg").GetComponent<RawImage>();
     }
 
-    private void SaveCreatedPicture(string path, byte[] bytes)
+    private void SaveCreatedPicture(string filename, byte[] bytes)
     {
-        string filename = "petever.png";
-        File.WriteAllBytes(path + filename, bytes);
+        string def_path = "/storage/emulated/0/DCIM/PetEver/";
+        string timestamp = System.DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss");
+        File.WriteAllBytes(def_path + filename + "-" + timestamp + ".png", bytes);
     }
 
     private IEnumerator Screenshot(Action<Texture2D> onFinished)
@@ -56,7 +57,7 @@ public class PiecesDone : MonoBehaviour
         // Encode to byte[], and Read the Image
         byte[] bytes = screenTex.EncodeToPNG();
         screenTex.LoadImage(bytes);
-        SaveCreatedPicture("/storage/emulated/0/DCIM/petever.png", bytes);
+        SaveCreatedPicture("petever", bytes);
         
         ri.texture = screenTex;
         ri.SetNativeSize();
@@ -67,6 +68,7 @@ public class PiecesDone : MonoBehaviour
         // Destroy(displayImg);
 
         onFinished?.Invoke(screenTex);
+        NewpageUIManager.CloseUI();
     }
     
     public void onPieceDoneClicked()


### PR DESCRIPTION
1. Saved image file name format : FILENAME-yyyy-MM-dd-HH-mm-ss.png
2. When click the complete btn, close the canvas