### PR TITLE
Unity/Scripts : Fix Build Warnings

### DIFF
--- a/Unity/PetEver/Assets/02.Scripts/Info/DogInformation.cs
+++ b/Unity/PetEver/Assets/02.Scripts/Info/DogInformation.cs
@@ -15,7 +15,6 @@ public class DogInformation : MonoBehaviour
 
     void Start()
     {
-        GameObject canvas = null;
         dogInfoCanvas = GameObject.FindGameObjectWithTag("DogInfo");
         if (dogInfoCanvas == null)
         {

--- a/Unity/PetEver/Assets/02.Scripts/MemorySceneUIScript/PictureZoomScript.cs
+++ b/Unity/PetEver/Assets/02.Scripts/MemorySceneUIScript/PictureZoomScript.cs
@@ -23,7 +23,7 @@ public class PictureZoomScript : MonoBehaviour
 
     void OnTriggerEnter(Collider coll) 
     {
-        if (coll.gameObject);
+        // if (coll.gameObject);
     }
 
 

--- a/Unity/PetEver/Assets/02.Scripts/TreeController.cs
+++ b/Unity/PetEver/Assets/02.Scripts/TreeController.cs
@@ -35,7 +35,7 @@ namespace BitBenderGames
 
         private Camera cam;
 
-        private Transform selectedPickableTransform;
+        // private Transform selectedPickableTransform;
         private Dictionary<Renderer, List<Color>> originalItemColorCache = new Dictionary<Renderer, List<Color>>();
 
         private void Awake()
@@ -209,7 +209,7 @@ namespace BitBenderGames
         public void OnPickableTransformDeselected(Transform pickableTransform)
         {
             pickableTransform.localScale = Vector3.one;
-            selectedPickableTransform = null;
+            // selectedPickableTransform = null;
             RevertToOriginalItemColor(pickableTransform);
         }
 


### PR DESCRIPTION
Fix Build Warnings
1) Assigned but not used variable
2) Declared but not used variable
3) Change to comment which is missing if statement