### PR TITLE
fixture camera in WorldScene & NewPageUI in memorialScene

### DIFF
--- a/Unity/PetEver/Assets/01.Scenes/MemorialScene.unity
+++ b/Unity/PetEver/Assets/01.Scenes/MemorialScene.unity
@@ -1887,6 +1887,7 @@ RectTransform:
   - {fileID: 5366081071170055767}
   - {fileID: 714730208}
   - {fileID: 1126970768}
+  - {fileID: 883076809}
   m_Father: {fileID: 0}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1928,6 +1929,42 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: -27.906, y: 180, z: 0}
+--- !u!1 &883076808
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 883076809}
+  m_Layer: 5
+  m_Name: TextAndSticker
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &883076809
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 883076808}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 793083374}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!65 &916464672
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Unity/PetEver/Assets/01.Scenes/WorldScene.unity
+++ b/Unity/PetEver/Assets/01.Scenes/WorldScene.unity
@@ -20473,7 +20473,7 @@ Light:
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
-  m_BoundingSphereOverride: {x: 2.484599e+27, y: 7.0341797e+28, z: 1.7077771e+19, w: 4.2329707e+21}
+  m_BoundingSphereOverride: {x: 9.036895e-38, y: 0, z: 0, w: NaN}
   m_UseBoundingSphereOverride: 0
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
@@ -28713,7 +28713,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.001
+  near clip plane: -20
   far clip plane: 100
   field of view: 60
   orthographic: 1
@@ -40383,7 +40383,7 @@ MonoBehaviour:
   m_Lens:
     FieldOfView: 60
     OrthographicSize: 20
-    NearClipPlane: 0.001
+    NearClipPlane: -20
     FarClipPlane: 100
     Dutch: 0
     ModeOverride: 0

--- a/Unity/PetEver/Assets/02.Scripts/DogTrackingCameraScript.cs
+++ b/Unity/PetEver/Assets/02.Scripts/DogTrackingCameraScript.cs
@@ -10,7 +10,7 @@ public class DogTrackingCameraScript : MonoBehaviour
     private CinemachineVirtualCamera vcam, cineCam;
     private CinemachineTransposer cineTransposer;
     public GameObject tPlayer;
-    private Vector3 offset; 
+    private Vector3 offset;
 
 
 
@@ -19,9 +19,9 @@ public class DogTrackingCameraScript : MonoBehaviour
     void Start()
     {
 
-       tPlayer = GameObject.FindGameObjectWithTag("OwnerDog");
-       //offset = gameObject.transform.position - tPlayer.transform.position;
-       offset = new Vector3(0f,0.5f,0f);
+        tPlayer = GameObject.FindGameObjectWithTag("OwnerDog");
+        //offset = gameObject.transform.position - tPlayer.transform.position;
+        offset = new Vector3(0f, 0.5f, 0f);
 
     }
 
@@ -32,8 +32,11 @@ public class DogTrackingCameraScript : MonoBehaviour
         {
             tPlayer = GameObject.FindGameObjectWithTag("OwnerDog");
         }
-        
-        gameObject.transform.position = tPlayer.transform.position + offset;
+
+        if (tPlayer != null)
+        {
+            gameObject.transform.position = tPlayer.transform.position + offset;
+        }
 
     }
 }

--- a/Unity/PetEver/Assets/02.Scripts/MakePath/DogEscort.cs
+++ b/Unity/PetEver/Assets/02.Scripts/MakePath/DogEscort.cs
@@ -5,7 +5,7 @@ using UnityEngine.AI;
 
 public class DogEscort : MonoBehaviour
 {
-    private NavMeshAgent navMeshAgent; 
+    private NavMeshAgent navMeshAgent;
     public static bool welcomeEscort;
     public static bool waitOwner;
     private Vector3[] escortPoint; // checkpoint when dog escorts Owner. if you want to add or delete checkpoint, modify 1.length of escortPoint array 2.number of checkPoint objects in WorldScene 
@@ -16,7 +16,7 @@ public class DogEscort : MonoBehaviour
     private float dis_Dog2Point; // distance between dog and point
     private int escortPointNum;
     private LineRenderer lineRenderer;
-   
+
     void Awake()
     {
         welcomeEscort = false;
@@ -25,11 +25,11 @@ public class DogEscort : MonoBehaviour
         escortPointNum = 0;
 
 
-        escortPoint = new Vector3[10]; 
+        escortPoint = new Vector3[10];
 
 
 
-       // escortPoint[2] = GameObject.Find("checkPoint3").GetComponent<Transform>().position;
+        // escortPoint[2] = GameObject.Find("checkPoint3").GetComponent<Transform>().position;
         //owner = GameObject.FindGameObjectWithTag("Owner");
 
 
@@ -48,7 +48,7 @@ public class DogEscort : MonoBehaviour
         escortPoint[7] = GameObject.Find("checkPoint8").GetComponent<Transform>().position;
         escortPoint[8] = GameObject.Find("checkPoint9").GetComponent<Transform>().position;
         escortPoint[9] = GameObject.Find("checkPoint10").GetComponent<Transform>().position;
-        
+
         navMeshAgent = GetComponent<NavMeshAgent>();
         owner = GameObject.FindGameObjectWithTag("Owner");
         emotionBubble = GameObject.Find("emotionCanvas").transform.Find("emotionBubble").gameObject;
@@ -60,7 +60,7 @@ public class DogEscort : MonoBehaviour
         //lineRenderer.material.color = Color.blue;
         lineRenderer.enabled = false;
 
-        
+
         StartCoroutine(DogEscorting());
 
     }
@@ -69,10 +69,12 @@ public class DogEscort : MonoBehaviour
     void Update()
     {
 
-        dis_Owner2Dog = Vector3.Distance(owner.transform.position, gameObject.transform.position);
-        dis_Owner2Point = Vector3.Distance(owner.transform.position, escortPoint[escortPointNum]);
+        if (owner != null)
+        {
+            dis_Owner2Dog = Vector3.Distance(owner.transform.position, gameObject.transform.position);
+            dis_Owner2Point = Vector3.Distance(owner.transform.position, escortPoint[escortPointNum]);
+        }
         dis_Dog2Point = Vector3.Distance(gameObject.transform.position, escortPoint[escortPointNum]);
-
 
 
     }
@@ -81,17 +83,17 @@ public class DogEscort : MonoBehaviour
     IEnumerator DogEscorting()
     {
 
-       // escortPoint.Length    
+        // escortPoint.Length    
         emotionBubble.SetActive(false);
         questionMark.SetActive(false);
 
-        while(true)
+        while (true)
         {
             if (welcomeEscort)
             {
-                lineRenderer.enabled = true;    
+                lineRenderer.enabled = true;
                 navMeshAgent.SetDestination(escortPoint[escortPointNum]);
-                lineRenderer.SetPosition(0,gameObject.transform.position);
+                lineRenderer.SetPosition(0, gameObject.transform.position);
 
                 navMeshAgent.stoppingDistance = 3.0f;
 
@@ -117,21 +119,21 @@ public class DogEscort : MonoBehaviour
                     emotionBubble.SetActive(false);
                     questionMark.SetActive(false);
 
-                    navMeshAgent.isStopped = false;   
+                    navMeshAgent.isStopped = false;
                 }
 
 
                 if (dis_Owner2Point < 7f)
                 {
-                    if (escortPointNum < (escortPoint.Length-1))
+                    if (escortPointNum < (escortPoint.Length - 1))
                     {
-                        escortPointNum++; 
+                        escortPointNum++;
                     }
 
                     else
                     {
                         welcomeEscort = false;
-                        lineRenderer.enabled = false;                   
+                        lineRenderer.enabled = false;
                         navMeshAgent.stoppingDistance = 10.0f;
 
                     }
@@ -149,8 +151,8 @@ public class DogEscort : MonoBehaviour
     {
         if (owner != null)
         {
-            Vector3 dir = (owner.transform.position-gameObject.transform.position);
-            gameObject.transform.rotation = Quaternion.Lerp(gameObject.transform.rotation, Quaternion.LookRotation(dir),Time.deltaTime*50f);
+            Vector3 dir = (owner.transform.position - gameObject.transform.position);
+            gameObject.transform.rotation = Quaternion.Lerp(gameObject.transform.rotation, Quaternion.LookRotation(dir), Time.deltaTime * 50f);
         }
     }
 

--- a/Unity/PetEver/Assets/02.Scripts/MakePath/DogSummonScript.cs
+++ b/Unity/PetEver/Assets/02.Scripts/MakePath/DogSummonScript.cs
@@ -20,28 +20,30 @@ public class DogSummonScript : MonoBehaviour
 
         if (dogSpecies[1] == "Bichon")
             dogRandomScale = Random.Range(0.85f, 1.0f);
-        else if(dogSpecies[1] == "PomeLong")
+        else if (dogSpecies[1] == "PomeLong")
             dogRandomScale = Random.Range(0.75f, 1.0f);
-        else if(dogSpecies[1] == "Pomeshort")
-            dogRandomScale = Random.Range(0.75f, 1.0f);       
-        else if(dogSpecies[1] == "Maltese")
+        else if (dogSpecies[1] == "Pomeshort")
             dogRandomScale = Random.Range(0.75f, 1.0f);
-        else if(dogSpecies[1] == "Poodle")
+        else if (dogSpecies[1] == "Maltese")
+            dogRandomScale = Random.Range(0.75f, 1.0f);
+        else if (dogSpecies[1] == "Poodle")
             dogRandomScale = Random.Range(0.85f, 1.0f);
-        else if(dogSpecies[1] == "Retriever")
+        else if (dogSpecies[1] == "Retriever")
             dogRandomScale = Random.Range(1.0f, 1.2f);
-        else if(dogSpecies[1] == "Shihtzu")
+        else if (dogSpecies[1] == "Shihtzu")
             dogRandomScale = Random.Range(0.75f, 1.0f);
-        else if(dogSpecies[1] == "Pug")
+        else if (dogSpecies[1] == "Pug")
             dogRandomScale = Random.Range(0.75f, 1.0f);
 
-        dogScale = new Vector3(1,1,1)*dogRandomScale;
+        dogScale = new Vector3(1, 1, 1) * dogRandomScale;
 
         dogNPC.transform.localScale = dogScale;
         dogNPC.tag = "DogNPC";
         dogNPC.layer = 0;
 
+        
         Instantiate(dogNPC, this.gameObject.transform.position, this.gameObject.transform.rotation);
+        
     }
 
     void Start()

--- a/Unity/PetEver/Assets/02.Scripts/MemorySceneUIScript/NewpageUIManager.cs
+++ b/Unity/PetEver/Assets/02.Scripts/MemorySceneUIScript/NewpageUIManager.cs
@@ -13,10 +13,7 @@ public class NewpageUIManager : MonoBehaviour
     public Button ImageBtn, StickerBtn, TextBtn, XBtn;
     public static GameObject UserInputTextBundle, StickerInventory, rawImageText;
     private static CanvasGroup newPageUI;
-
-    private Vector3 createPoint, stickercreatePoint;
-
-
+    public static Transform[] trashCan;
     // Start is called before the first frame update
     void Start()
     {
@@ -43,20 +40,28 @@ public class NewpageUIManager : MonoBehaviour
     }
     public static void CloseUI()
     {
+        trashCan = GameObject.Find("TextAndSticker").GetComponentsInChildren<Transform>();    
+
+        if(trashCan != null)
+        {
+            for(int i = 1; i < trashCan.Length; i++)
+            {
+                Destroy(trashCan[i].gameObject);
+            }
+        }
         HideCanvasGroup(newPageUI);
     }
 
     public void GetText()
     {
         UserInputTextBundle = Resources.Load<GameObject>("Prefabs/UserInputTextBundle");
-        UserInputTextBundle = Instantiate(UserInputTextBundle, createPoint, Quaternion.identity, GameObject.Find("MemorialSceneCanvas").GetComponent<RectTransform>());
+        UserInputTextBundle = Instantiate(UserInputTextBundle, GameObject.Find("TextAndSticker").GetComponent<RectTransform>());
     }
 
     public void GetSticker()
     {
-        stickercreatePoint = createPoint + new Vector3(0f, 0f, 0f);
         StickerInventory = Resources.Load<GameObject>("Prefabs/StickerInventory");
-        StickerInventory = Instantiate(StickerInventory, stickercreatePoint, Quaternion.identity, GameObject.Find("MemorialSceneCanvas").GetComponent<RectTransform>());
+        StickerInventory = Instantiate(StickerInventory, GameObject.Find("TextAndSticker").GetComponent<RectTransform>());
     }
 
     public void GetImage()

--- a/Unity/PetEver/Assets/02.Scripts/MemorySceneUIScript/StickerCtrlScript.cs
+++ b/Unity/PetEver/Assets/02.Scripts/MemorySceneUIScript/StickerCtrlScript.cs
@@ -23,7 +23,7 @@ public class StickerCtrlScript : MonoBehaviour, IPointerClickHandler, IPointerDo
     {
         stickerSprite = gameObject.GetComponent<Image>().sprite;
         stickerImage = gameObject.GetComponent<Image>();
-        MemorialSceneCanvas = GameObject.Find("MemorialSceneCanvas");
+        MemorialSceneCanvas = GameObject.Find("TextAndSticker");
 
         if (stickerSprite != null)
         {
@@ -41,7 +41,6 @@ public class StickerCtrlScript : MonoBehaviour, IPointerClickHandler, IPointerDo
         {
             if(Time.time - timePressStarted > durationThreshold)
             {
-                Debug.Log("press");
                 longPressTriggered = true;
                 SelectSticker();
             }


### PR DESCRIPTION
1. WorldScene 카메라  짤리는 문제 해결
- 해결방법 : FollowCam의 Near Clip Plane 값 조정

2. NewPageUI 캔버스 위치 틀어짐 조정
 - 해결방법 : 생성시 부모만 지정, Prefab 자체에서 부모 캔버스의 크기에 맞추도록 Constraint 설정

3. Null Exception 처리
- WorldScene부터 시작할떄 DogEscort, DogSummonScript에 null 처리 안된것들 추가